### PR TITLE
[Chore] Add PR template and branch-first workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Background and Purpose
+
+Why is this change needed? Link context and clarify the goal.
+
+## What changed
+
+- 
+
+## How to test
+
+```bash
+./gradlew test
+```
+
+## Risk / Rollback
+
+- Risk:
+- Rollback:
+
+## Non-goals
+
+- 
+
+## Checklist
+
+- [ ] Tests passing
+- [ ] No unrelated files included
+- [ ] Docs updated (if needed)
+
+## Issue
+
+Closes #<issue-number>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ The agent MUST follow these rules at all times.
 - MUST NOT: Skip phases or act autonomously.
 - MUST: Stop immediately and ask the user if requirements are unclear or incomplete.
 - MUST: Prioritize correctness, clarity, and user intent over speed.
+- MUST: Use GitHub MCP for GitHub operations (Issue/Branch/Commit/Push/PR).
 
 ---
 
@@ -59,6 +60,8 @@ The agent MUST create a [`plan.md`](./plan.md) file containing:
 - MUST: If the user approved this [`plan.md`](./plan.md), register the problem described in [`plan.md`](./plan.md) as a GitHub Issue using GitHub MCP.
   - The Issue format is file at [`./skills/git-conventions/SKILL.md`](./skills/git-conventions/SKILL.md) 
 - The Issue MUST reflect the contents of [`plan.md`](./plan.md).
+- MUST: After Issue creation, create a working branch (per `skills/git-conventions`) **before** entering TDD Mode.
+- MUST: All tests/development happen on that branch (do not work directly on `main`).
 - MUST-NOT: DO NOT Write After TDD phase (including Development)
 
 ---

--- a/skills/git-conventions/SKILL.md
+++ b/skills/git-conventions/SKILL.md
@@ -94,6 +94,9 @@ fix/456-auth-token-bug
 refactor/789-cleanup-utils
 ```
 
+Notes:
+- Agent-created branches may be prefixed with `codex/` (e.g., `codex/feat/123-user-login`) to match the agent’s branch prefix requirement.
+
 ---
 
 ## 6. Push & Pull Request Workflow
@@ -125,3 +128,25 @@ git push origin <branch-name>
 ```
 Closes #<issue-number>
 ```
+
+### 6.4 Pull Request Title Convention
+- MUST: Follow the same category prefix format as Issues
+```
+[Feature|Bug|Refactor|Docs|Chore] Brief description
+```
+
+### 6.5 Pull Request Body Template (Recommended)
+PR body should include:
+- Background and Purpose
+- What changed (summary bullets)
+- How to test (exact commands / steps)
+- Risk / Rollback plan
+- Non-goals (explicitly out of scope)
+- Checklist
+  - [ ] Tests passing (e.g., `./gradlew test`)
+  - [ ] No unrelated files included
+  - [ ] Docs updated (if needed)
+- Issue connection: `Closes #<issue-number>`
+
+### 6.6 Pull Request Template File
+- Recommended: Add `.github/pull_request_template.md` so GitHub auto-populates PR descriptions.


### PR DESCRIPTION
Standardizes PR conventions and adds a GitHub PR template.

- Extend `skills/git-conventions/SKILL.md` with PR title/body conventions
- Add `.github/pull_request_template.md` for auto-filled PR descriptions
- Update `AGENTS.md` to enforce branch-first workflow and GitHub MCP usage

Closes #5